### PR TITLE
Bugfix) Double deployment

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,8 +1,8 @@
 name: CI & CD with Google Cloud Run
 on:
   push:
-    branches:
-      - '**' # All Branch should be checked for Integration
+    branches-ignore:
+      - 'main'
   pull_request:
     branches:
       - 'main'


### PR DESCRIPTION
# 🤠 작업 내용
<!-- 간단하게 작업한 내용을 작성해주세요 -->
PR을 통해 main에 병합할 때, push 와 pull_request 이벤트가 동시에 발생하면서 gitaction이 두 번 발생한다. 이것을 방지하기 위해 github branch rule 세팅에서 main에 merge/push 시 pull_request가 필요하도록 강제했고, push 이벤트에서 main을 무시하도록 바꿨다.